### PR TITLE
Fixes the help text for the mc-apt command

### DIFF
--- a/apt/mc-apt
+++ b/apt/mc-apt
@@ -11,8 +11,9 @@ options = rpcoptions do |parser, options|
     parser.separator "  upgrades        - list number of available package upgrades"
     parser.separator "  installed       - list number of installed packages"
     parser.separator "  clean           - clean package archive files (i.e. apt-get clean)"
+    parser.separator "  update          - perform system update (i.e. apt-get update)"
     parser.separator "  upgrade         - perform system upgrade (i.e. apt-get upgrade)"
-    parser.separator "  update          - perform system dist-upgrade (i.e. apt-get dist-upgrade)"
+    parser.separator "  distupgrade     - perform system dist-upgrade (i.e. apt-get dist-upgrade)"
 end
 
 if ARGV.length == 1


### PR DESCRIPTION
The --help output for the mc-apt command states that the "updates" command will perform an apt-get dist-upgrade, when it only runs apt-get update. This fixes that and also adds the distupgrade command to the help output.
