### PR TITLE
Adding the option to clear out all broken package installations

### DIFF
--- a/apt/apt.ddl
+++ b/apt/apt.ddl
@@ -30,6 +30,14 @@ action "clean", :description => "Remove all package archive files" do
           :display_as  => "Cleaning Execution"
 end
 
+action "removebroken", :description => "Remove all broken packages" do
+    display :always
+
+    output "status",
+          :description => "Status of purging execution",
+          :display_as  => "Purging Execution"
+end
+
 action "update", :description => "Update repository information" do
     display :always
 

--- a/apt/apt.rb
+++ b/apt/apt.rb
@@ -21,6 +21,10 @@ module MCollective
                 reply.data = %x[/usr/bin/apt-get clean > /dev/null 2>&1 && echo OK || echo FAILED].chomp
             end
 
+            def removebroken_action
+                reply.data = %x[/usr/bin/dpkg -l | grep '^iF' | /usr/bin/awk '{ print $2}' | /usr/bin/xargs sudo /usr/bin/apt-get -y remove` > /dev/null 2>&1 && echo OK || echo FAILED].chomp
+            end
+
             def update_action
                 reply.data = %x[/usr/bin/apt-get update > /dev/null 2>&1 && echo OK || echo FAILED].chomp
             end

--- a/apt/mc-apt
+++ b/apt/mc-apt
@@ -11,6 +11,7 @@ options = rpcoptions do |parser, options|
     parser.separator "  upgrades        - list number of available package upgrades"
     parser.separator "  installed       - list number of installed packages"
     parser.separator "  clean           - clean package archive files (i.e. apt-get clean)"
+    parser.separator "  removebroken    - remove incomplete packages from broken installations"
     parser.separator "  update          - perform system update (i.e. apt-get update)"
     parser.separator "  upgrade         - perform system upgrade (i.e. apt-get upgrade)"
     parser.separator "  distupgrade     - perform system dist-upgrade (i.e. apt-get dist-upgrade)"


### PR DESCRIPTION
@mstanislav I haven't tested this in quite literally, years, however I just realized I never submitted this PR after I had patched it for my own use. Looks like there haven't been any further commits since my change either, so it will merge in perfectly.

Wanted to offer the PR in-case anyone can get any use out of it. Cheers!